### PR TITLE
[561] fix public_hash setted when paying with new card

### DIFF
--- a/components/AdyenPayments.vue
+++ b/components/AdyenPayments.vue
@@ -34,7 +34,7 @@ export default {
   },
 
   methods: {
-    
+
     async createForm() {
       if (
         this.payment &&
@@ -143,6 +143,10 @@ export default {
                   );
                   this.$emit("providedAdyenData");
                 } else {
+                  self.$store.dispatch(
+                    "payment-adyen/setPublicHash",
+                    null
+                  );
                   self.$store.dispatch("notification/spawnNotification", {
                     type: "error",
                     message: i18n.t("Bad data provided for the card"),
@@ -150,6 +154,11 @@ export default {
                   });
                 }
                 return;
+              } else {
+                self.$store.dispatch(
+                  "payment-adyen/setPublicHash",
+                  null
+                );
               }
 
               this.$store.dispatch("payment-adyen/setCardData", {


### PR DESCRIPTION
Fix for

> found a bug with a use case:
> 
>     place order saving card > add new items to cart > go to checkout > try to place order with new card
> 
> order fails cause we are sending paymentMethod=adyen_cc_vault instead of adyen_cc for new card